### PR TITLE
add message formatting kwargs into sending data

### DIFF
--- a/systemd/__init__.py
+++ b/systemd/__init__.py
@@ -1,5 +1,5 @@
 package_info = "Python systemd wrapper"
-version_info = (0, 12, 0)
+version_info = (0, 13, 0)
 
 
 author_info = (

--- a/systemd/journal.py
+++ b/systemd/journal.py
@@ -1,3 +1,4 @@
+import collections
 import uuid
 import logging
 import traceback
@@ -142,8 +143,14 @@ class JournaldLogHandler(logging.Handler):
         )
         data['thread_name'] = data.pop('threadName')
 
-        for idx, item in enumerate(data.pop('args', [])):
-            data['argument_%d' % idx] = str(item)
+        args = data.pop('args', [])
+        if args and len(args) == 1 and isinstance(args[0], collections.Mapping) and args[0]:
+            for key, value in args[0].items():
+                key = '%s_2' % key if key in data else str(key)
+                data[key] = value
+        else:
+            for idx, item in enumerate(args):
+                data['argument_%d' % idx] = str(item)
 
         if tb_message:
             data["traceback"] = tb_message

--- a/systemd/journal.py
+++ b/systemd/journal.py
@@ -146,7 +146,7 @@ class JournaldLogHandler(logging.Handler):
         args = data.pop('args', [])
         if args and len(args) == 1 and isinstance(args[0], collections.Mapping) and args[0]:
             for key, value in args[0].items():
-                key = '%s_2' % key if key in data else str(key)
+                key = 'argument_%s' % key if key in data else str(key)
                 data[key] = value
         else:
             for idx, item in enumerate(args):

--- a/systemd/journal.py
+++ b/systemd/journal.py
@@ -146,8 +146,7 @@ class JournaldLogHandler(logging.Handler):
         args = data.pop('args', [])
         if args and len(args) == 1 and isinstance(args[0], collections.Mapping) and args[0]:
             for key, value in args[0].items():
-                key = 'argument_%s' % key if key in data else str(key)
-                data[key] = value
+                data['argument_%s' % key] = value
         else:
             for idx, item in enumerate(args):
                 data['argument_%d' % idx] = str(item)


### PR DESCRIPTION
Logger supports formating messages with named placeholders like this:
logger.warning('Auth failed for %(login)s', {'login': some_login})
It will be convenient to have these formatting arguments in journal by their names instead of names like 'argument_N'