### PR TITLE
Fix type-annotation of notify parameter

### DIFF
--- a/cysystemd/daemon.py
+++ b/cysystemd/daemon.py
@@ -1,5 +1,6 @@
 import logging
 from collections import namedtuple
+from typing import Union
 from enum import Enum, unique
 
 from ._daemon import sd_notify
@@ -30,7 +31,7 @@ class Notification(Enum):
 
 def notify(
     notification: Notification,
-    value: int = None,
+    value: Union[str, int] = None,
     unset_environment: bool = False,
     return_exceptions: bool = True,
 ):


### PR DESCRIPTION
The value parameter of the notify-function currently has the type-annotation int, while in the docstring, its type can be int or str:
:param value: str or int value for non constant notifications